### PR TITLE
Fix typo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ Bleach
 .. image:: https://badge.fury.io/py/bleach.svg
    :target: http://badge.fury.io/py/bleach
 
-Bleach is a allowed-list-based HTML sanitizing library that escapes or strips
+Bleach is an allowed-list-based HTML sanitizing library that escapes or strips
 markup and attributes.
 
 Bleach can also linkify text safely, applying filters that Django's ``urlize``


### PR DESCRIPTION
Same thing needs fixing on the homepage by someone with access:

![image](https://user-images.githubusercontent.com/1324225/33083240-7e4e93b4-cee7-11e7-9f7d-c65550da2a94.png)
